### PR TITLE
Fix set-power-state command in CLI

### DIFF
--- a/pymadoka/cli.py
+++ b/pymadoka/cli.py
@@ -168,14 +168,14 @@ async def get_power_state(obj):
     return await obj["madoka"].power_state.query()
   
    
-@click.command()
+@cli.command()
 @click.pass_obj
 @coro
 @click.argument('power-state',
               type=click.Choice(['ON','OFF'], case_sensitive=True))
 async def set_power_state(obj,power_state):
     """Turn ON or OFF the HVAC."""
-    return await obj["madoka"].set_point.update(PowerStateStatus(power_state == "ON"))
+    return await obj["madoka"].power_state.update(PowerStateStatus(power_state == "ON"))
   
         
 @cli.command()


### PR DESCRIPTION
This PR fixes two small bugs in the CLI interface that:
1. Prevented the ``set-power-state`` command from registering in ``click``
2. Attempted to set ``set_point`` instead of ``power_state`` property of the controller 

After fixing the first bug, we can see that ``set-power-state`` now shows up in set of available commands when running ``pymadoka --help``:

```
Usage: cli.py [OPTIONS] COMMAND [ARGS]...

Options:
  -a, --address TEXT              Bluetooth MAC address of the thermostat
                                  [required]
  -d, --adapter TEXT              Name of the Bluetooth adapter to be used for
                                  the connection  [default: hci0]
  --force-disconnect / --not-force-disconnect
                                  Should disconnect the device to ensure it is
                                  recognized (recommended)  [default: force-
                                  disconnect]
  -t, --device-discovery-timeout INTEGER
                                  Timeout for Bluetooth device scan in seconds
                                  [default: 5]
  -o, --log-output PATH           Path to the log output file
  --debug                         Enable debug logging
  --verbose                       Enable versbose logging
  --clean                         Enable clean output
  --version                       Show the version and exit.
  --help                          Show this message and exit.

Commands:
  get-clean-filter-indicator  Get status of the Clean Filter indicator.
  get-fan-speed               Get cooling and heating fan speeds.
  get-info                    Get info of the device.
  get-operation-mode          Get the operation mode.
  get-power-state             Check if the HVAC is turned on.
  get-set-point               Get target temperatures in Celsius degrees.
  get-status                  Get status of all the thermostat features.
  get-temperatures            Get temperatures as read by the thermostat.
  reset-clean-filter-timer    Reset the Clean Filter indicator timer.
  set-fan-speed               Set cooling and heating fan speeds.
  set-operation-mode          Set the operation mode.
  set-power-state             Turn ON or OFF the HVAC.
  set-set-point               Set cooling/heating target temperatures in...
```

The second bug can only be confirmed by running on an actual device, but it has been tested locally and works.