### PR TITLE
remove importing discover from bleak, as it is no longer there in newer versions

### DIFF
--- a/pymadoka/connection.py
+++ b/pymadoka/connection.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from enum import Enum
 
-from bleak import BleakClient,BleakScanner,discover
+from bleak import BleakClient,BleakScanner
 from typing import Dict
 
 from pymadoka.transport import Transport, TransportDelegate


### PR DESCRIPTION
Hello there,

bleak no longer exposes discover, and it's not being used anyway, this is stopping daiking madoka from being able to be installed in recent HA versions.

Thanks